### PR TITLE
:bug: Fix reading PANOPTIC_PORT env variable

### DIFF
--- a/panoptic_back/panoptic/main.py
+++ b/panoptic_back/panoptic/main.py
@@ -25,8 +25,8 @@ def start():
     panoptic.load_data()
 
     HOST = os.getenv("PANOPTIC_HOST", None)
-    # default port for Panoptic backend
-    PORT = os.getenv("PANOPTIC_PORT", 8000)
+    # default port for Panoptic backend is 8000
+    PORT = int(os.getenv("PANOPTIC_PORT", 8000))
 
     # FastAPI setup
     app = FastAPI(lifespan=lifespan)


### PR DESCRIPTION
Hello again! 

Unless mistaken, os.getenv() returns a string while uvicorn.run() expects an integer, as shown on the [uvicorn website](https://www.uvicorn.org/#running-programmatically). I had an issue when setting a custom value for PANOPTIC_PORT with `ENV PANOPTIC_PORT=8860` in my custom Dockerfile, for instance.

Thank you!